### PR TITLE
1. added example. 2. Use new crypto lib import golang.org/x/crypto/sha3

### DIFF
--- a/api/crypto-sha3-hashes.go
+++ b/api/crypto-sha3-hashes.go
@@ -1,10 +1,10 @@
 package api
 
 import (
-	"github.com/ethereum/go-ethereum/crypto/sha3"
+	"golang.org/x/crypto/sha3"
 )
 
 func NewKeccak256() *GosHash {
-	h := sha3.NewKeccak256()
+	h := sha3.NewLegacyKeccak256()
 	return fromGosHash(h)
 }

--- a/examples/generate_wallet.go
+++ b/examples/generate_wallet.go
@@ -25,4 +25,18 @@ func main() {
 	address := api.PubkeyToAddress(pub)
 	//	fmt.Println(address)
 	fmt.Println(address.Hex())
+
+	// 4. get address from Hex private key
+	priv_key, err :=api.HexToECDSA("e09ae607ff4fb3320133e73a76d4fc8e5b784663b2f34662fb910f3ff5d8d5ef")
+	if err != nil {
+		log.Fatal(err)
+	}
+	pub_key := priv_key.Public()
+	address = api.PubkeyToAddress(pub_key)
+	if address.Hex() == "0x15d48078AB8532b8857e0568311fc3792a5562ab"{
+		fmt.Println(address.Hex())
+	} else {
+		log.Fatal(err)
+	}
+
 }


### PR DESCRIPTION
example to convert Hex private key to Hex account address.
golang.org/x/crypto/sha3 used in new ETH versions. Backward compatible.